### PR TITLE
Added BrickID as third input parameter

### DIFF
--- a/run1analysis/recoparameters/linkingloop.sh
+++ b/run1analysis/recoparameters/linkingloop.sh
@@ -1,38 +1,54 @@
 #!/bin/bash
 
+cd ./b0000$3
+eval 'echo $(pwd)'
+
 if [[ $# -eq 0 ]] ; then
     echo 'Script for performing the two required linking steps. Usage is: '
     echo ' '
-    echo 'source linkingloop.sh nfrom_plate nto_plate'
+    echo 'source linkingloop.sh nfrom_plate nto_plate brickID'
     echo ' '
-    echo 'just replace nfrom_plate and nto_plate with corresponding numbers'
+    echo 'just replace nfrom_plate and nto_plate brickID with corresponding numbers e.g. 1 3 51 for plate 1 to 3 of W5B1'
     return 0
 fi
 
-makescanset -set=11.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2 -reset
+makescanset -set=$3.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2 -reset
 
 echo "Starting pre-linking"
 
 cp firstlink.rootrc link.rootrc
 
-makescanset -set=11.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
+makescanset -set=$3.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
 
-emlink -set=11.0.0.0 -new -v=2
+emlink -set=$3.0.0.0 -new -v=2
 
-cp b000011.0.0.0.link.ps plot_prelink/b000011.0.0.0.prelink_$1_$2.ps
+cp b0000$3.0.0.0.link.ps plot_prelink/b0000$3.0.0.0.prelink_$1_$2.ps
 
 #copying cp.root from first linking, to check shrinkage distributions later on
-for iplate in $(seq $2 $1)
+for iplate in $(eval echo {$1..$2}) 
  do
-  cp p00$iplate/11.$iplate.0.0.cp.root p00$iplate/11.$iplate.0.0.firstlinkcp.root
+
+  if [ $iplate -le 9 ]
+   then
+   cp p00$iplate/$3.$iplate.0.0.cp.root p00$iplate/$3.$iplate.0.0.firstlinkcp.root
+   echo "written p00$iplate/$3.$iplate.0.0.cp.root p00$iplate/$3.$iplate.0.0.firstlinkcp.root"
+
+  elif [ $iplate -le 99 ]
+   then 
+   cp p0$iplate/$3.$iplate.0.0.cp.root p0$iplate/$3.$iplate.0.0.firstlinkcp.root
+   echo " written p0$iplate/$3.$iplate.0.0.cp.root p0$iplate/$3.$iplate.0.0.firstlinkcp.root "
+  else
+   cp p$iplate/$3.$iplate.0.0.cp.root p$iplate/$3.$iplate.0.0.firstlinkcp.root
+   echo " written p$iplate/$3.$iplate.0.0.cp.root p$iplate/$3.$iplate.0.0.firstlinkcp.root "
+  fi
  done
 
 echo "Starting true linking"
 
 cp secondlink.rootrc link.rootrc
 
-makescanset -set=11.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
+makescanset -set=$3.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
 
-emlink -set=11.0.0.0 -new -v=2
+emlink -set=$3.0.0.0 -new -v=2
 
-cp b000011.0.0.0.link.ps plot_link/b000011.0.0.0.link_$1_$2.ps
+cp b0000$3.0.0.0.link.ps plot_link/b0000$3.0.0.0.link_$1_$2.ps

--- a/run1analysis/recoparameters/linkingloop.sh
+++ b/run1analysis/recoparameters/linkingloop.sh
@@ -9,23 +9,8 @@ if [[ $# -eq 0 ]] ; then
     return 0
 fi
 
-if [[ $3 -le 9 ]] 
-then
-
-   brickID=0$3
-   workdir=b00000$3
-elif  [ $3 -gt 9 ] && [ $3 -le 99 ] 
-then
-
-   brickID=$3
-   workdir=b0000$3
-elif [[ $3 -gt 99 ]] 
-then
-
-   brickID=$3
-   workdir=b000$3
-
-fi
+workdir="$(printf "b%0*d\n" 6 $3)"
+echo "trying to enter $workdir"
 
 if [ ! -d "$workdir" ]
 then 
@@ -46,6 +31,12 @@ makescanset -set=$brickID.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
 
 emlink -set=$brickID.0.0.0 -new -v=2
 
+if [ ! -d "./plot_prelink" ]
+then 
+   echo "The plot prelink directory does not exist! Creating it."
+   mkdir ./plot_prelink
+fi
+
 cp $workdir.0.0.0.link.ps plot_prelink/$workdir.0.0.0.prelink_$1_$2.ps
 
 
@@ -55,17 +46,17 @@ for iplate in $(eval echo {$1..$2})
 
   if [ $iplate -le 9 ]
    then
-   cp p00$iplate/$brickID.$iplate.0.0.cp.root p00$iplate/$brickID.$iplate.0.0.firstlinkcp.root
-   echo "written p00$iplate/$brickID.$iplate.0.0.cp.root p00$iplate/$brickID.$iplate.0.0.firstlinkcp.root"
+   cp p00$iplate/$brickID.$iplate.0.0.cp.root p00$iplate/$3.$iplate.0.0.firstlinkcp.root
+   echo "written p00$iplate/$brickID.$iplate.0.0.cp.root p00$iplate/$3.$iplate.0.0.firstlinkcp.root"
 
   elif [ $iplate -le 99 ]
    then 
-   cp p0$iplate/$brickID.$iplate.0.0.cp.root p0$iplate/$brickID.$iplate.0.0.firstlinkcp.root
-   echo " written p0$iplate/$brickID.$iplate.0.0.cp.root p0$iplate/$brickID.$iplate.0.0.firstlinkcp.root "
+   cp p0$iplate/$brickID.$iplate.0.0.cp.root p0$iplate/$3.$iplate.0.0.firstlinkcp.root
+   echo " written p0$iplate/$brickID.$iplate.0.0.cp.root p0$iplate/$3.$iplate.0.0.firstlinkcp.root "
 
   else
-   cp p$iplate/$brickID.$iplate.0.0.cp.root p$iplate/$brickID.$iplate.0.0.firstlinkcp.root
-   echo " written p$iplate/$brickID.$iplate.0.0.cp.root p$iplate/$brickID.$iplate.0.0.firstlinkcp.root "
+   cp p$iplate/$brickID.$iplate.0.0.cp.root p$iplate/$3.$iplate.0.0.firstlinkcp.root
+   echo " written p$iplate/$brickID.$iplate.0.0.cp.root p$iplate/$3.$iplate.0.0.firstlinkcp.root "
   fi
  done
 
@@ -76,5 +67,11 @@ cp secondlink.rootrc link.rootrc
 makescanset -set=$brickID.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
 
 emlink -set=$brickID.0.0.0 -new -v=2
+
+if [ ! -d "./plot_link" ]
+then 
+   echo "The plot link directory does not exist! Creating it."
+   mkdir ./plot_link
+fi
 
 cp $workdir.0.0.0.link.ps plot_link/$workdir.0.0.0.link_$1_$2.ps

--- a/run1analysis/recoparameters/linkingloop.sh
+++ b/run1analysis/recoparameters/linkingloop.sh
@@ -1,28 +1,53 @@
 #!/bin/bash
 
-cd ./b0000$3
-eval 'echo $(pwd)'
-
 if [[ $# -eq 0 ]] ; then
     echo 'Script for performing the two required linking steps. Usage is: '
     echo ' '
-    echo 'source linkingloop.sh nfrom_plate nto_plate brickID'
+    echo 'source linkingloop.sh nfrom_plate nto_plate'
     echo ' '
-    echo 'just replace nfrom_plate and nto_plate brickID with corresponding numbers e.g. 1 3 51 for plate 1 to 3 of W5B1'
+    echo 'just replace nfrom_plate and nto_plate with corresponding numbers'
     return 0
 fi
 
-makescanset -set=$3.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2 -reset
+if [[ $3 -le 9 ]] 
+then
+
+   brickID=0$3
+   workdir=b00000$3
+elif  [ $3 -gt 9 ] && [ $3 -le 99 ] 
+then
+
+   brickID=$3
+   workdir=b0000$3
+elif [[ $3 -gt 99 ]] 
+then
+
+   brickID=$3
+   workdir=b000$3
+
+fi
+
+if [ ! -d "$workdir" ]
+then 
+   echo "The directory does not exist!"
+   return 0 
+fi
+
+cd ./$workdir
+eval 'echo we are in $(pwd)'
+
+makescanset -set=$brickID.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2 -reset
 
 echo "Starting pre-linking"
 
 cp firstlink.rootrc link.rootrc
 
-makescanset -set=$3.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
+makescanset -set=$brickID.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
 
-emlink -set=$3.0.0.0 -new -v=2
+emlink -set=$brickID.0.0.0 -new -v=2
 
-cp b0000$3.0.0.0.link.ps plot_prelink/b0000$3.0.0.0.prelink_$1_$2.ps
+cp $workdir.0.0.0.link.ps plot_prelink/$workdir.0.0.0.prelink_$1_$2.ps
+
 
 #copying cp.root from first linking, to check shrinkage distributions later on
 for iplate in $(eval echo {$1..$2}) 
@@ -30,16 +55,17 @@ for iplate in $(eval echo {$1..$2})
 
   if [ $iplate -le 9 ]
    then
-   cp p00$iplate/$3.$iplate.0.0.cp.root p00$iplate/$3.$iplate.0.0.firstlinkcp.root
-   echo "written p00$iplate/$3.$iplate.0.0.cp.root p00$iplate/$3.$iplate.0.0.firstlinkcp.root"
+   cp p00$iplate/$brickID.$iplate.0.0.cp.root p00$iplate/$brickID.$iplate.0.0.firstlinkcp.root
+   echo "written p00$iplate/$brickID.$iplate.0.0.cp.root p00$iplate/$brickID.$iplate.0.0.firstlinkcp.root"
 
   elif [ $iplate -le 99 ]
    then 
-   cp p0$iplate/$3.$iplate.0.0.cp.root p0$iplate/$3.$iplate.0.0.firstlinkcp.root
-   echo " written p0$iplate/$3.$iplate.0.0.cp.root p0$iplate/$3.$iplate.0.0.firstlinkcp.root "
+   cp p0$iplate/$brickID.$iplate.0.0.cp.root p0$iplate/$brickID.$iplate.0.0.firstlinkcp.root
+   echo " written p0$iplate/$brickID.$iplate.0.0.cp.root p0$iplate/$brickID.$iplate.0.0.firstlinkcp.root "
+
   else
-   cp p$iplate/$3.$iplate.0.0.cp.root p$iplate/$3.$iplate.0.0.firstlinkcp.root
-   echo " written p$iplate/$3.$iplate.0.0.cp.root p$iplate/$3.$iplate.0.0.firstlinkcp.root "
+   cp p$iplate/$brickID.$iplate.0.0.cp.root p$iplate/$brickID.$iplate.0.0.firstlinkcp.root
+   echo " written p$iplate/$brickID.$iplate.0.0.cp.root p$iplate/$brickID.$iplate.0.0.firstlinkcp.root "
   fi
  done
 
@@ -47,8 +73,8 @@ echo "Starting true linking"
 
 cp secondlink.rootrc link.rootrc
 
-makescanset -set=$3.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
+makescanset -set=$brickID.0.0.0 -dzbase=195 -from_plate=$1 -to_plate=$2 -v=2
 
-emlink -set=$3.0.0.0 -new -v=2
+emlink -set=$brickID.0.0.0 -new -v=2
 
-cp b0000$3.0.0.0.link.ps plot_link/b0000$3.0.0.0.link_$1_$2.ps
+cp $workdir.0.0.0.link.ps plot_link/$workdir.0.0.0.link_$1_$2.ps


### PR DESCRIPTION
Can be called from emureco_*/RUN*/ with 3 parameters: from_plate to_plate BrickID (defined by wall number in the tens position and brick number for the units, eg W5B1->51) instead of having to change the file.