### PR TITLE
Optimizing CSV file production and data merge 

### DIFF
--- a/scipy_conversion/csvconversion_data.py
+++ b/scipy_conversion/csvconversion_data.py
@@ -140,30 +140,24 @@ def builddataframe(brick, path = "..", cutstring = "1", major = 0, minor = 0, ne
 
  return df
 
-def applyconversion(nbrick):
- '''convert couples ROOT files into a csv'''
-
- #df = builddataframe(nbrick,  cutstring = "eCHI2P<2.0&&s.eW>10&&eN1==1&&eN2==1")
- df = builddataframe(nbrick,  cutstring = "eN1==1&&eN2==1")
-
- return df
-
 #the two steps can now be done together, without an intermediate file
 nbrick = int(sys.argv[1])
+major = int(sys.argv[2])
+minor = int(sys.argv[3])
 #starting all conversion steps
-df = applyconversion(nbrick)
+df = builddataframe(nbrick,cutstring="eN1<=1&&eN2<=1&&s1.eFlag>=0&&s2.eFlag>=0",major = major, minor = minor)
 
 lastplate = int(df.name[0:3])
 firstplate = int(df.name[4:7])
 
 df['Plate'] = lastplate - df['PID']
 
-print ("Dataframe ready, now adding tracks")
+print ("Dataframe ready, NOT adding tracks")
 
-import fedra2scipy_utils
+#import fedra2scipy_utils
 
-df = fedra2scipy_utils.addtrackindex(df, sys.argv[2])
-df = df.drop(labels='PID',axis=1)
+#df = fedra2scipy_utils.addtrackindex(df, sys.argv[2]) #for now, do not add tracks!
+#df = df.drop(labels='PID',axis=1)
 
 df.to_csv('brick{}_{}_{}.csv'.format(nbrick,lastplate,firstplate),index=False) #should contain from plate to plate info, so we can get PID info
 

--- a/scipy_conversion/fedra2scipy_utils.py
+++ b/scipy_conversion/fedra2scipy_utils.py
@@ -336,7 +336,7 @@ def retrievetrackinfo(df, trackfilename):
 
   
 
-def addvertexindex(df,vertexfilename):
+def addvertexindex(vertexfilename):
   '''adding vertex index to dataframe. Requires Track Index'''
   vertexfile = r.TFile.Open(vertexfilename)
   vertextree = vertexfile.Get("vtx")
@@ -374,7 +374,5 @@ def addvertexindex(df,vertexfilename):
   VertexSarr = list(VertexS.values())
   VertexEarr = list(VertexE.values())
   dfvertices = pd.DataFrame({"FEDRATrackID":TrackIDarr, "VertexS":VertexSarr, "VertexE":VertexEarr},columns = labels, dtype = int)
-  
-  #dfwithvertices = df.merge(dfvertices,how='left', on = ["TrackID"])
 
   return dfvertices  


### PR DESCRIPTION
Dear all,

While generating some example data files for Filips with RUN1, I noticed that the code is still not optimized for huge memory data (i.e. RUN1 and onwards).

Basically, the pandas merge calls require too much memory, and make the function crash even if the dataframe with volume-tracks and vertices were successfully executed.

For now, a quick and dirty solution was commenting the merge calls, and storing the dataframes into separate csv.
In the future, we may want to add the merge possibility as an user option, and even investigating if scipy and pandas libraries offer more efficient merge fuctions for huge data.

Please let me know if you have comments or suggestions,
Antonio